### PR TITLE
Fix handling of multiple completion scopes

### DIFF
--- a/lib/xcodesnippet/commands/install.rb
+++ b/lib/xcodesnippet/commands/install.rb
@@ -57,7 +57,11 @@ def extract_front_matter!
                         end
     @snippet.title = front_matter["title"] || ""
     @snippet.summary = front_matter["summary"] || ""
-    @snippet.completion_scopes = [front_matter["completion-scope"]] || front_matter["completion-scopes"] || "All"
+    @snippet.completion_scopes = case
+                                 when front_matter["completion-scope"] then [front_matter["completion-scope"]]
+                                 when front_matter["completion-scopes"] then front_matter["completion-scopes"]
+                                 else "All"
+                                 end
     @snippet.identifier = SecureRandom.uuid().upcase
     @snippet.is_user_snippet = true
     @snippet.version = 0


### PR DESCRIPTION
When the YAML front matter contains no "completion-scope", the
expression `[front_matter["completion-scope"]]` evaluates to `[nil]`,
which is truthy, so the rest of the chain is not evaluated and the
snippet is assigned `completion_scopes` of `[nil]`.

As it happens, `[nil]` is serialised as `<array><data>BAgw</data></array>`.

When a code snippet containing that "completion scope" is present,
Xcode crashes as soon as I try to enter any text in a place where
a snippet might be admissible.

This change replaces the chain of `||` operators with a `case`
block.  This leads to some ugly repetition in the resulting code,
but at least it doesn't crash Xcode. ;-)